### PR TITLE
Cache and reuse the graph leaf nodes

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ const (
 var (
 	flagBlockStart string
 	flagBlockEnd   string
+	isCacheEnabled bool
 )
 
 func main() {
@@ -38,7 +39,7 @@ func main() {
 	res, err := parser.Parse(src, flagBlockStart, flagBlockEnd)
 	exitOnErr(err)
 
-	fmt.Print(renderer.Render(res))
+	fmt.Print(renderer.Render(res, isCacheEnabled))
 }
 
 func configureFlags() {
@@ -53,7 +54,7 @@ func configureFlags() {
 
 		fmt.Print("EXAMPLE(s):\n\n")
 		fmt.Printf("  %s -from '/****' -to '****/' MyClass.java | dot -Tpng > output.png\n", name)
-		fmt.Printf("  %s config.yml | dot -Tpng > output.png\n\n", name)
+		fmt.Printf("  %s -cacheValues config.yml | dot -Tpng > output.png\n\n", name)
 
 		fmt.Print("FLAGS:\n\n")
 		flag.CommandLine.SetOutput(os.Stdout)
@@ -70,6 +71,7 @@ func configureFlags() {
 
 	flag.CommandLine.StringVar(&flagBlockStart, "from", "", "pattern that marks the beginning of the YAML block")
 	flag.CommandLine.StringVar(&flagBlockEnd, "to", "", "pattern that marks the end of the YAML block")
+	flag.CommandLine.BoolVar(&isCacheEnabled, "cacheValues", false, "re-use the leaf nodes")
 
 	flag.CommandLine.Parse(os.Args[1:])
 }

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -1,38 +1,65 @@
 package renderer
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/lucasepe/dot"
 	"gopkg.in/yaml.v2"
 )
 
 func TestRender(t *testing.T) {
 	tmp := []yaml.MapItem{
 		{Key: "apiVersion", Value: "v3"},
+		{Key: "web", Value: "not cached"},
 		{Key: "kind", Value: "Pod"},
 		{Key: "metadata", Value: map[string]interface{}{
 			"name": "rss-site",
 			"labels": map[string]interface{}{
-				"app": "web",
+				"app":     "web",
+				"other":   "network",
+				"another": "web",
 			},
 		},
 		},
 	}
 
-	got := Render(tmp)
+	got := Render(tmp, true)
+	fmt.Println(got)
 
 	id := "n1"
 	if n := got.FindNodeByID(id); n == nil {
-		t.Errorf("node with label [%v] not found", id)
+		t.Errorf("node with id [%v] not found", id)
 	}
 
 	id = "n2"
 	if n := got.FindNodeByID(id); n == nil {
-		t.Errorf("node with label [%v] not found", id)
+		t.Errorf("node with id [%v] not found", id)
 	}
 
 	id = "n43"
 	if n := got.FindNodeByID(id); n != nil {
-		t.Errorf("node with label [%v] should not exist", id)
+		t.Errorf("node with id [%v] should not exist", id)
 	}
+
+	// Test caching of "web" leaf node
+	label := "web"
+	if nn := FindAllByLabel(got, label); len(nn) != 1 {
+		t.Errorf("Incorrect number '%d' of nodes with label [%v]", len(nn), label)
+	}
+}
+
+// FindAllByLabel returns all nodes with a label
+// TODO: move to dot package
+func FindAllByLabel(g *dot.Graph, label string) (founds []*dot.Node) {
+	g.VisitNodes(func(node *dot.Node) (done bool) {
+		if l := node.Value("label"); l != nil {
+			// l.(string) type assertion causes panic: interface conversion: interface {} is dot.HTML, not string
+			if fmt.Sprintf("%v", l) == label {
+				founds = append(founds, node)
+			}
+		}
+		return false
+	})
+	return
 }


### PR DESCRIPTION
I changed the code for my use case.  The `-cacheValues` cmd line flag is turned off by default.