### PR TITLE
Add support for accepting YAML strings from stdin

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ and create this graph:
 
 ![](./_examples/Box.java.png)
 
+## Piping YAML strings
+
+You can also pipe YAML strings directly into `yml2dot`, allowing for dynamic generation and transformation of YAML data. This is particularly useful when combining `yml2dot` with other command-line tools in a Unix-style pipeline.
+
+For example, to visualize a YAML string without creating an intermediate file:
+
+```bash
+echo "apiVersion: v1\nkind: Pod\nmetadata:\n  name: mypod" | yml2dot | dot -Tpng > mypod.png
+```
+
+Or, to dynamically generate a YAML configuration and immediately visualize it:
+
+```bash
+generate-yaml-config | yml2dot | dot -Tpng > config.png
+```
+
+This feature enhances `yml2dot`'s flexibility and integration into automated workflows and scripts.
 
 # How to install?
 

--- a/main.go
+++ b/main.go
@@ -1,9 +1,10 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -26,12 +27,7 @@ var (
 func main() {
 	configureFlags()
 
-	if flag.CommandLine.Arg(0) == "" {
-		flag.CommandLine.Usage()
-		os.Exit(2)
-	}
-
-	src, err := os.Open(flag.Args()[0])
+	src, err := inputSource()
 	exitOnErr(err)
 	defer src.Close()
 
@@ -49,11 +45,13 @@ func configureFlags() {
 		fmt.Printf("Turn YAML into beautiful Graph.\n\n")
 
 		fmt.Print("USAGE:\n\n")
-		fmt.Printf("  %s [flags] <path/to/your/file>\n\n", name)
+		fmt.Printf("  %s [flags] <path/to/your/file>\n", name)
+		fmt.Printf("  echo \"your yaml here\" | %s\n\n", name)
 
 		fmt.Print("EXAMPLE(s):\n\n")
 		fmt.Printf("  %s -from '/****' -to '****/' MyClass.java | dot -Tpng > output.png\n", name)
-		fmt.Printf("  %s config.yml | dot -Tpng > output.png\n\n", name)
+		fmt.Printf("  %s config.yml | dot -Tpng > output.png\n", name)
+		fmt.Printf("  cat config.yml | %s | dot -Tpng > output.png\n\n", name)
 
 		fmt.Print("FLAGS:\n\n")
 		flag.CommandLine.SetOutput(os.Stdout)
@@ -76,6 +74,14 @@ func configureFlags() {
 
 func appName() string {
 	return filepath.Base(os.Args[0])
+}
+
+// inputSource determines the source of the input, either from a file or stdin.
+func inputSource() (io.ReadCloser, error) {
+	if flag.CommandLine.Arg(0) == "" {
+		return os.Stdin, nil
+	}
+	return os.Open(flag.Args()[0])
 }
 
 // exitOnErr check for an error and eventually exit


### PR DESCRIPTION
Related to #1

This pull request introduces the ability to accept YAML strings from stdin, enhancing the flexibility of the `yml2dot` tool. 

- **Input Handling**: Modifies `main.go` to determine the source of input dynamically. If no file path is provided, it reads from stdin, allowing for piping YAML strings directly into the tool.
- **Usage Instructions**: Updates the usage instructions in both `main.go` and `README.md` to include examples of piping YAML strings. This helps users understand the new feature and how to use it effectively.
- **Documentation**: Adds a new "Piping YAML strings" section in `README.md` with examples and explanations, making it easier for users to grasp the concept and utility of the feature.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lucasepe/yml2dot/issues/1?shareId=e95577e2-9fed-4fa0-b4b8-e182746ed265).